### PR TITLE
In consume_socket on the tv_nsec member of timeout is not initialized…

### DIFF
--- a/squeasel.c
+++ b/squeasel.c
@@ -4501,6 +4501,7 @@ static int consume_socket(struct sq_context *ctx, struct socket *sp) {
     clock_get_time(cclock, &mts);
     mach_port_deallocate(mach_task_self(), cclock);
     timeout.tv_sec = mts.tv_sec;
+    timeout.tv_nsec = (long) mts.tv_nsec;
 #endif
 
     ctx->num_free_threads++;


### PR DESCRIPTION
…. As such it's set randomly which could be a negative value. When this occurs,  the thread enters an infinite loop:

I1214 11:39:22.705610 24137728 webserver.cc:264] Webserver: Failed timedwait: Invalid argument
I1214 11:39:22.705617 24137728 webserver.cc:264] Webserver: Failed timedwait: Invalid argument
I1214 11:39:22.705626 24137728 webserver.cc:264] Webserver: Failed timedwait: Invalid argument
I1214 11:39:22.705636 24137728 webserver.cc:264] Webserver: Failed timedwait: Invalid argument

This change initializes the tv_nsec member as well using mach_timespec.tv_nsec which is a similar value
defined here:

http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/osfmk/mach/clock_types.h
