### PR TITLE
Fix some keepalive issues, port latest changes from Impala

### DIFF
--- a/squeasel.c
+++ b/squeasel.c
@@ -150,6 +150,7 @@ typedef int socklen_t;
 
 static const char *http_500_error = "Internal Server Error";
 
+#include <openssl/crypto.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
@@ -161,6 +162,8 @@ static const char *http_500_error = "Internal Server Error";
 #ifndef SSL_OP_NO_TLSv1_1
 #define SSL_OP_NO_TLSv1_1 0x10000000U
 #endif
+
+#define OPENSSL_MIN_VERSION_WITH_TLS_1_1 0x10001000L
 
 static const char *month_names[] = {
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -4261,8 +4264,16 @@ static int set_ssl_option(struct sq_context *ctx) {
   if (sq_strcasecmp(ssl_version, "tlsv1") == 0) {
     // No-op - don't exclude any TLS protocols.
   } else if (sq_strcasecmp(ssl_version, "tlsv1.1") == 0) {
+    if (SSLeay() < OPENSSL_MIN_VERSION_WITH_TLS_1_1) {
+      cry(fc(ctx), "Unsupported TLS version: %s", ssl_version);
+      return 0;
+    }
     options |= SSL_OP_NO_TLSv1;
   } else if (sq_strcasecmp(ssl_version, "tlsv1.2") == 0) {
+    if (SSLeay() < OPENSSL_MIN_VERSION_WITH_TLS_1_1) {
+      cry(fc(ctx), "Unsupported TLS version: %s", ssl_version);
+      return 0;
+    }
     options |= (SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
   } else {
     cry(fc(ctx), "%s: unknown SSL version: %s", __func__, ssl_version);
@@ -4285,7 +4296,11 @@ static int set_ssl_option(struct sq_context *ctx) {
     return 0;
   }
 
-  SSL_CTX_set_options(ctx->ssl_ctx, options);
+  if ((SSL_CTX_set_options(ctx->ssl_ctx, options) & options) != options) {
+    cry(fc(ctx), "SSL_CTX_set_options (server) error: could not set options (%d)",
+        options);
+    return 0;
+  }
 
   if (ctx->config[SSL_PRIVATE_KEY_PASSWORD] != NULL) {
     SSL_CTX_set_default_passwd_cb(ctx->ssl_ctx, ssl_password_callback);

--- a/squeasel.c
+++ b/squeasel.c
@@ -1066,6 +1066,7 @@ static int alloc_vprintf2(char **buf, const char *fmt, va_list ap) {
     if (!*buf) break;
     va_copy(ap_copy, ap);
     len = vsnprintf(*buf, size, fmt, ap_copy);
+    va_end(ap_copy);
   }
 
   return len;
@@ -1085,12 +1086,14 @@ static int alloc_vprintf(char **buf, size_t size, const char *fmt, va_list ap) {
   // On second pass, actually print the message.
   va_copy(ap_copy, ap);
   len = vsnprintf(NULL, 0, fmt, ap_copy);
+  va_end(ap_copy);
 
   if (len < 0) {
     // C runtime is not standard compliant, vsnprintf() returned -1.
     // Switch to alternative code path that uses incremental allocations.
     va_copy(ap_copy, ap);
     len = alloc_vprintf2(buf, fmt, ap);
+    va_end(ap_copy);
   } else if (len > (int) size &&
       (size = len + 1) > 0 &&
       (*buf = (char *) malloc(size)) == NULL) {
@@ -1098,6 +1101,7 @@ static int alloc_vprintf(char **buf, size_t size, const char *fmt, va_list ap) {
   } else {
     va_copy(ap_copy, ap);
     vsnprintf(*buf, size, fmt, ap_copy);
+    va_end(ap_copy);
   }
 
   return len;
@@ -1120,7 +1124,9 @@ int sq_vprintf(struct sq_connection *conn, const char *fmt, va_list ap) {
 int sq_printf(struct sq_connection *conn, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  return sq_vprintf(conn, fmt, ap);
+  int ret_val = sq_vprintf(conn, fmt, ap);
+  va_end(ap);
+  return ret_val;
 }
 
 int sq_url_decode(const char *src, int src_len, char *dst,
@@ -4519,6 +4525,7 @@ struct sq_connection *sq_download(const char *host, int port, int use_ssl,
     sq_close_connection(conn);
     conn = NULL;
   }
+  va_end(ap);
 
   return conn;
 }


### PR DESCRIPTION
Tested with Kudu webserver-test that this still passes. Modified Kudu to enable keepalive and don't see any slow tests, whereas before several tests would hang for 30 seconds stopping the server if keepalive was enabled.